### PR TITLE
Sketch: Bytestring diagnostics preservation

### DIFF
--- a/src/encode/bytes.rs
+++ b/src/encode/bytes.rs
@@ -78,7 +78,7 @@ fn negative_to_bytes(bytes: &mut Vec<u8>, value: u64, bitwidth: IntegerWidth) {
     integer_to_bytes(bytes, value, bitwidth, 1);
 }
 
-fn definite_bytestring_to_bytes(bytes: &mut Vec<u8>, ByteString { data, bitwidth }: &ByteString) {
+fn definite_bytestring_to_bytes(bytes: &mut Vec<u8>, ByteString { data, bitwidth, .. }: &ByteString) {
     integer_to_bytes(bytes, data.len() as u64, *bitwidth, 2);
     bytes.extend_from_slice(data);
 }

--- a/src/encode/hex.rs
+++ b/src/encode/hex.rs
@@ -271,7 +271,7 @@ fn bytes_to_hex(encoding: Option<Encoding>, data: &[u8]) -> impl Iterator<Item =
 }
 
 fn definite_bytestring_to_hex(encoding: Option<Encoding>, bytestring: &ByteString) -> Line {
-    let ByteString { ref data, bitwidth } = *bytestring;
+    let ByteString { ref data, bitwidth, .. } = *bytestring;
 
     let mut line = length_to_hex(Some(data.len()), Some(bitwidth), 2, "bytes");
 
@@ -1137,7 +1137,7 @@ fn typed_array<const LEN: usize>(
     name: &str,
     convert: impl Fn([u8; LEN]) -> String,
 ) -> Vec<Line> {
-    if let DataItem::ByteString(ByteString { data, bitwidth }) = value {
+    if let DataItem::ByteString(ByteString { data, bitwidth, .. }) = value {
         if data.len() % LEN == 0 {
             let mut line = length_to_hex(Some(data.len()), Some(*bitwidth), 2, "bytes");
             // TODO: Use slice::array_chunks when stable

--- a/src/encode/mod.rs
+++ b/src/encode/mod.rs
@@ -2,10 +2,17 @@ mod bytes;
 mod diag;
 mod hex;
 
-#[derive(Copy, Clone)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
 #[allow(clippy::enum_variant_names)]
 pub(crate) enum Encoding {
     Base16,
     Base64,
     Base64Url,
+}
+
+impl Encoding {
+    /// Return overrider if given, otherwise return self
+    pub(crate) fn override_with(self, overrider: Option<Self>) -> Self {
+        overrider.unwrap_or(self)
+    }
 }

--- a/src/parse/binary.rs
+++ b/src/parse/binary.rs
@@ -88,7 +88,7 @@ fn definite_bytestring(input: &[u8]) -> IResult<&[u8], ByteString> {
         .map_err(|_| Err::Error(make_error(input, ErrorKind::LengthValue)))?;
     let (input, data) = take_bytes(length)(input)?;
     let data = data.to_owned();
-    Ok((input, ByteString { data, bitwidth }))
+    Ok((input, ByteString::new(data).with_bitwidth(bitwidth)))
 }
 
 fn indefinite_bytestring(input: &[u8]) -> IResult<&[u8], DataItem> {

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -65,9 +65,27 @@ pub struct Simple(pub u8);
 /// [RFC 2.1]: https://tools.ietf.org/html/rfc7049#section-2.1
 pub struct ByteString {
     /// The raw binary data in this byte string
-    pub data: Vec<u8>,
+    pub(crate) data: Vec<u8>,
     /// The bitwidth used for encoding the length
-    pub bitwidth: IntegerWidth,
+    pub(crate) bitwidth: IntegerWidth,
+}
+
+impl ByteString {
+    /// Create a new ByteString
+    ///
+    /// The bitwidth of the encoding is initially unknown
+    pub fn new(data: impl Into<Vec<u8>>) -> Self {
+        let data = data.into();
+        Self {
+            data,
+            bitwidth: IntegerWidth::Unknown,
+        }
+    }
+
+    /// Builder for ByteStrings with a fixed bit width
+    pub fn with_bitwidth(self, bitwidth: IntegerWidth) -> Self {
+        Self { bitwidth, ..self }
+    }
 }
 
 #[derive(Debug, Eq, PartialEq, Clone)]

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -56,6 +56,9 @@ pub struct Tag(pub u64);
 pub struct Simple(pub u8);
 
 #[derive(Debug, Eq, PartialEq, Clone)]
+// FIXME: Deriving PartialEq here means different diag notations do differ; we'll have to make a
+// choice at some point whether Eq means Eq in all representations and choices (probably that's
+// indeed the right one).
 /// A string of raw bytes with no direct attached meaning.
 ///
 /// May be assigned a meaning by being enclosed in a [semantic tag](Tag).
@@ -68,6 +71,8 @@ pub struct ByteString {
     pub(crate) data: Vec<u8>,
     /// The bitwidth used for encoding the length
     pub(crate) bitwidth: IntegerWidth,
+    /// Encoding used for diagnostic notation
+    pub(crate) diag_encoding: Option<crate::encode::Encoding>,
 }
 
 impl ByteString {
@@ -79,6 +84,7 @@ impl ByteString {
         Self {
             data,
             bitwidth: IntegerWidth::Unknown,
+            diag_encoding: None,
         }
     }
 

--- a/tests/bytes.rs
+++ b/tests/bytes.rs
@@ -14,10 +14,9 @@ mod utils;
 testcases! {
     mod diag {
         empty(diag2value, value2diag) {
-            DataItem::ByteString(ByteString {
-                data: vec![],
-                bitwidth: IntegerWidth::Unknown,
-            }),
+            DataItem::ByteString(ByteString::new(
+                vec![]
+            )),
             {
                 "h''",
                 "h''",
@@ -25,10 +24,9 @@ testcases! {
         }
 
         hello(diag2value, value2diag) {
-            DataItem::ByteString(ByteString {
-                data: b"hello"[..].into(),
-                bitwidth: IntegerWidth::Unknown,
-            }),
+            DataItem::ByteString(ByteString::new(
+                *b"hello"
+            )),
             {
                 "h'68656c6c6f'",
                 "h'68656c6c6f'",
@@ -36,10 +34,9 @@ testcases! {
         }
 
         alpha(diag2value, value2diag) {
-            DataItem::ByteString(ByteString {
-                data: b"abcdefghijklmnopqrstuvwxyz"[..].into(),
-                bitwidth: IntegerWidth::Unknown,
-            }),
+            DataItem::ByteString(ByteString::new(
+                *b"abcdefghijklmnopqrstuvwxyz"
+            )),
             {
                 "h'6162636465666768696a6b6c6d6e6f707172737475767778797a'",
                 "h'6162636465666768696a6b6c6d6e6f707172737475767778797a'",
@@ -47,10 +44,9 @@ testcases! {
         }
 
         non_alpha(diag2value, value2diag) {
-            DataItem::ByteString(ByteString {
-                data: vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-                bitwidth: IntegerWidth::Unknown,
-            }),
+            DataItem::ByteString(ByteString::new(
+                vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+            )),
             {
                 "h'000102030405060708090a'",
                 "h'000102030405060708090a'",
@@ -60,10 +56,10 @@ testcases! {
 
     mod tiny {
         empty(hex2value, value2hex) {
-            DataItem::ByteString(ByteString {
-                data: vec![],
-                bitwidth: IntegerWidth::Zero,
-            }),
+            DataItem::ByteString(ByteString::new(
+                    vec![]
+                ).with_bitwidth(IntegerWidth::Zero)
+            ),
             indoc!(r#"
                 40 # bytes(0)
                    #   ""
@@ -71,10 +67,10 @@ testcases! {
         }
 
         hello(hex2value, value2hex) {
-            DataItem::ByteString(ByteString {
-                data: b"hello"[..].into(),
-                bitwidth: IntegerWidth::Zero,
-            }),
+            DataItem::ByteString(ByteString::new(
+                    *b"hello"
+                ).with_bitwidth(IntegerWidth::Zero)
+            ),
             indoc!(r#"
                 45            # bytes(5)
                    68656c6c6f #   "hello"
@@ -84,10 +80,10 @@ testcases! {
 
     mod u8 {
         empty(hex2value, value2hex) {
-            DataItem::ByteString(ByteString {
-                data: vec![],
-                bitwidth: IntegerWidth::Eight,
-            }),
+            DataItem::ByteString(ByteString::new(
+                    vec![]
+                ).with_bitwidth(IntegerWidth::Eight)
+            ),
             indoc!(r#"
                 58 00 # bytes(0)
                       #   ""
@@ -95,10 +91,10 @@ testcases! {
         }
 
         hello(hex2value, value2hex) {
-            DataItem::ByteString(ByteString {
-                data: b"hello"[..].into(),
-                bitwidth: IntegerWidth::Eight,
-            }),
+            DataItem::ByteString(ByteString::new(
+                    *b"hello"
+                ).with_bitwidth(IntegerWidth::Eight)
+            ),
             indoc!(r#"
                 58 05         # bytes(5)
                    68656c6c6f #   "hello"
@@ -106,10 +102,10 @@ testcases! {
         }
 
         alpha(hex2value, value2hex) {
-            DataItem::ByteString(ByteString {
-                data: b"abcdefghijklmnopqrstuvwxyz"[..].into(),
-                bitwidth: IntegerWidth::Eight,
-            }),
+            DataItem::ByteString(ByteString::new(
+                    *b"abcdefghijklmnopqrstuvwxyz"
+                ).with_bitwidth(IntegerWidth::Eight)
+            ),
             indoc!(r#"
                 58 1a                               # bytes(26)
                    6162636465666768696a6b6c6d6e6f70 #   "abcdefghijklmnop"
@@ -118,10 +114,10 @@ testcases! {
         }
 
         non_alpha(hex2value, value2hex) {
-            DataItem::ByteString(ByteString {
-                data: vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-                bitwidth: IntegerWidth::Eight,
-            }),
+            DataItem::ByteString(ByteString::new(
+                    vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+                ).with_bitwidth(IntegerWidth::Eight)
+            ),
             indoc!(r#"
                 58 0b                     # bytes(11)
                    000102030405060708090a #   "\x00\x01\x02\x03\x04\x05\x06\x07\x08\t\n"
@@ -131,10 +127,10 @@ testcases! {
 
     mod u16 {
         empty(hex2value, value2hex) {
-            DataItem::ByteString(ByteString {
-                data: vec![],
-                bitwidth: IntegerWidth::Sixteen,
-            }),
+            DataItem::ByteString(ByteString::new(
+                    vec![]
+                ).with_bitwidth(IntegerWidth::Sixteen)
+            ),
             indoc!(r#"
                 59 0000 # bytes(0)
                         #   ""
@@ -142,10 +138,10 @@ testcases! {
         }
 
         hello(hex2value, value2hex) {
-            DataItem::ByteString(ByteString {
-                data: b"hello"[..].into(),
-                bitwidth: IntegerWidth::Sixteen,
-            }),
+            DataItem::ByteString(ByteString::new(
+                    *b"hello"
+                ).with_bitwidth(IntegerWidth::Sixteen)
+            ),
             indoc!(r#"
                 59 0005       # bytes(5)
                    68656c6c6f #   "hello"
@@ -153,10 +149,10 @@ testcases! {
         }
 
         alpha(hex2value, value2hex) {
-            DataItem::ByteString(ByteString {
-                data: b"abcdefghijklmnopqrstuvwxyz"[..].into(),
-                bitwidth: IntegerWidth::Sixteen,
-            }),
+            DataItem::ByteString(ByteString::new(
+                    *b"abcdefghijklmnopqrstuvwxyz"
+                ).with_bitwidth(IntegerWidth::Sixteen)
+            ),
             indoc!(r#"
                 59 001a                             # bytes(26)
                    6162636465666768696a6b6c6d6e6f70 #   "abcdefghijklmnop"
@@ -167,10 +163,10 @@ testcases! {
 
     mod u32 {
         empty(hex2value, value2hex) {
-            DataItem::ByteString(ByteString {
-                data: vec![],
-                bitwidth: IntegerWidth::ThirtyTwo,
-            }),
+            DataItem::ByteString(ByteString::new(
+                    vec![]
+                ).with_bitwidth(IntegerWidth::ThirtyTwo)
+            ),
             indoc!(r#"
                 5a 00000000 # bytes(0)
                             #   ""
@@ -178,10 +174,10 @@ testcases! {
         }
 
         hello(hex2value, value2hex) {
-            DataItem::ByteString(ByteString {
-                data: b"hello"[..].into(),
-                bitwidth: IntegerWidth::ThirtyTwo,
-            }),
+            DataItem::ByteString(ByteString::new(
+                    *b"hello"
+                ).with_bitwidth(IntegerWidth::ThirtyTwo)
+            ),
             indoc!(r#"
                 5a 00000005   # bytes(5)
                    68656c6c6f #   "hello"
@@ -189,10 +185,10 @@ testcases! {
         }
 
         alpha(hex2value, value2hex) {
-            DataItem::ByteString(ByteString {
-                data: b"abcdefghijklmnopqrstuvwxyz"[..].into(),
-                bitwidth: IntegerWidth::ThirtyTwo,
-            }),
+            DataItem::ByteString(ByteString::new(
+                    *b"abcdefghijklmnopqrstuvwxyz"
+                ).with_bitwidth(IntegerWidth::ThirtyTwo)
+            ),
             indoc!(r#"
                 5a 0000001a                         # bytes(26)
                    6162636465666768696a6b6c6d6e6f70 #   "abcdefghijklmnop"
@@ -203,10 +199,10 @@ testcases! {
 
     mod u64 {
         empty(hex2value, value2hex) {
-            DataItem::ByteString(ByteString {
-                data: vec![],
-                bitwidth: IntegerWidth::SixtyFour,
-            }),
+            DataItem::ByteString(ByteString::new(
+                    vec![]
+                ).with_bitwidth(IntegerWidth::SixtyFour)
+            ),
             indoc!(r#"
                 5b 0000000000000000 # bytes(0)
                                     #   ""
@@ -214,10 +210,10 @@ testcases! {
         }
 
         hello(hex2value, value2hex) {
-            DataItem::ByteString(ByteString {
-                data: b"hello"[..].into(),
-                bitwidth: IntegerWidth::SixtyFour,
-            }),
+            DataItem::ByteString(ByteString::new(
+                    *b"hello"
+                ).with_bitwidth(IntegerWidth::SixtyFour)
+            ),
             indoc!(r#"
                 5b 0000000000000005 # bytes(5)
                    68656c6c6f       #   "hello"
@@ -225,10 +221,10 @@ testcases! {
         }
 
         alpha(hex2value, value2hex) {
-            DataItem::ByteString(ByteString {
-                data: b"abcdefghijklmnopqrstuvwxyz"[..].into(),
-                bitwidth: IntegerWidth::SixtyFour,
-            }),
+            DataItem::ByteString(ByteString::new(
+                    *b"abcdefghijklmnopqrstuvwxyz"
+                ).with_bitwidth(IntegerWidth::SixtyFour)
+            ),
             indoc!(r#"
                 5b 000000000000001a                 # bytes(26)
                    6162636465666768696a6b6c6d6e6f70 #   "abcdefghijklmnop"
@@ -249,10 +245,7 @@ testcases! {
 
             one_empty(diag2value, value2diag) {
                 DataItem::IndefiniteByteString(vec![
-                    ByteString {
-                        data: vec![],
-                        bitwidth: IntegerWidth::Unknown,
-                    },
+                    ByteString::new(vec![]),
                 ]),
                 {
                     "(_h'')",
@@ -262,14 +255,8 @@ testcases! {
 
             some_empty(diag2value, value2diag) {
                 DataItem::IndefiniteByteString(vec![
-                    ByteString {
-                        data: vec![],
-                        bitwidth: IntegerWidth::Unknown,
-                    },
-                    ByteString {
-                        data: vec![],
-                        bitwidth: IntegerWidth::Unknown,
-                    },
+                    ByteString::new(vec![]),
+                    ByteString::new(vec![]),
                 ]),
                 {
                     "(_h'',h'')",
@@ -279,10 +266,7 @@ testcases! {
 
             hello(diag2value, value2diag) {
                 DataItem::IndefiniteByteString(vec![
-                    ByteString {
-                        data: b"hello"[..].into(),
-                        bitwidth: IntegerWidth::Unknown,
-                    },
+                    ByteString::new(*b"hello"),
                 ]),
                 {
                     "(_h'68656c6c6f')",
@@ -292,14 +276,8 @@ testcases! {
 
             hello_world(diag2value, value2diag) {
                 DataItem::IndefiniteByteString(vec![
-                    ByteString {
-                        data: b"hello"[..].into(),
-                        bitwidth: IntegerWidth::Unknown,
-                    },
-                    ByteString {
-                        data: b"world"[..].into(),
-                        bitwidth: IntegerWidth::Unknown,
-                    },
+                    ByteString::new(*b"hello"),
+                    ByteString::new(*b"world"),
                 ]),
                 {
                     "(_h'68656c6c6f',h'776f726c64')",
@@ -309,22 +287,10 @@ testcases! {
 
             alpha(diag2value, value2diag) {
                 DataItem::IndefiniteByteString(vec![
-                    ByteString {
-                        data: b"abc"[..].into(),
-                        bitwidth: IntegerWidth::Unknown,
-                    },
-                    ByteString {
-                        data: b""[..].into(),
-                        bitwidth: IntegerWidth::Unknown,
-                    },
-                    ByteString {
-                        data: b"defghijklmnopqrstuv"[..].into(),
-                        bitwidth: IntegerWidth::Unknown,
-                    },
-                    ByteString {
-                        data: b"wxyz"[..].into(),
-                        bitwidth: IntegerWidth::Unknown,
-                    },
+                    ByteString::new(*b"abc"),
+                    ByteString::new(*b""),
+                    ByteString::new(*b"defghijklmnopqrstuv"),
+                    ByteString::new(*b"wxyz"),
                 ]),
                 {
                     "(_h'616263',h'',h'6465666768696a6b6c6d6e6f70717273747576',h'7778797a')",
@@ -341,14 +307,12 @@ testcases! {
 
             non_alpha(diag2value, value2diag) {
                 DataItem::IndefiniteByteString(vec![
-                    ByteString {
-                        data: vec![0, 1, 2, 3, 4],
-                        bitwidth: IntegerWidth::Unknown,
-                    },
-                    ByteString {
-                        data: vec![5, 6, 7, 8, 9, 10],
-                        bitwidth: IntegerWidth::Unknown,
-                    },
+                    ByteString::new(
+                        vec![0, 1, 2, 3, 4]
+                    ),
+                    ByteString::new(
+                        vec![5, 6, 7, 8, 9, 10]
+                    ),
                 ]),
                 {
                     "(_h'0001020304',h'05060708090a')",
@@ -368,10 +332,8 @@ testcases! {
 
             one_empty(hex2value, value2hex) {
                 DataItem::IndefiniteByteString(vec![
-                    ByteString {
-                        data: "".into(),
-                        bitwidth: IntegerWidth::Zero,
-                    },
+                    ByteString::new("")
+                        .with_bitwidth(IntegerWidth::Zero),
                 ]),
                 indoc!(r#"
                     5f    # bytes(*)
@@ -383,14 +345,10 @@ testcases! {
 
             some_empty(hex2value, value2hex) {
                 DataItem::IndefiniteByteString(vec![
-                    ByteString {
-                        data: "".into(),
-                        bitwidth: IntegerWidth::Zero,
-                    },
-                    ByteString {
-                        data: "".into(),
-                        bitwidth: IntegerWidth::Zero,
-                    },
+                    ByteString::new("")
+                        .with_bitwidth(IntegerWidth::Zero),
+                    ByteString::new("")
+                        .with_bitwidth(IntegerWidth::Zero),
                 ]),
                 indoc!(r#"
                     5f    # bytes(*)
@@ -404,14 +362,10 @@ testcases! {
 
             hello_world(hex2value, value2hex) {
                 DataItem::IndefiniteByteString(vec![
-                    ByteString {
-                        data: b"hello"[..].into(),
-                        bitwidth: IntegerWidth::Zero,
-                    },
-                    ByteString {
-                        data: b"world"[..].into(),
-                        bitwidth: IntegerWidth::Sixteen,
-                    },
+                    ByteString::new(*b"hello")
+                        .with_bitwidth(IntegerWidth::Zero),
+                    ByteString::new(*b"world")
+                        .with_bitwidth(IntegerWidth::Sixteen),
                 ]),
                 indoc!(r#"
                     5f               # bytes(*)
@@ -425,22 +379,14 @@ testcases! {
 
             alpha(hex2value, value2hex) {
                 DataItem::IndefiniteByteString(vec![
-                    ByteString {
-                        data: b"abc"[..].into(),
-                        bitwidth: IntegerWidth::Zero,
-                    },
-                    ByteString {
-                        data: "".into(),
-                        bitwidth: IntegerWidth::Sixteen,
-                    },
-                    ByteString {
-                        data: b"defghijklmnopqrstuv"[..].into(),
-                        bitwidth: IntegerWidth::ThirtyTwo,
-                    },
-                    ByteString {
-                        data: b"wxyz"[..].into(),
-                        bitwidth: IntegerWidth::SixtyFour,
-                    },
+                    ByteString::new(*b"abc")
+                        .with_bitwidth(IntegerWidth::Zero),
+                    ByteString::new("")
+                        .with_bitwidth(IntegerWidth::Sixteen),
+                    ByteString::new(*b"defghijklmnopqrstuv")
+                        .with_bitwidth(IntegerWidth::ThirtyTwo),
+                    ByteString::new(*b"wxyz")
+                        .with_bitwidth(IntegerWidth::SixtyFour),
                 ]),
                 indoc!(r#"
                     5f                                     # bytes(*)
@@ -459,14 +405,12 @@ testcases! {
 
             non_alpha(hex2value, value2hex) {
                 DataItem::IndefiniteByteString(vec![
-                    ByteString {
-                        data: vec![0, 1, 2, 3, 4],
-                        bitwidth: IntegerWidth::Zero,
-                    },
-                    ByteString {
-                        data: vec![5, 6, 7, 8, 9, 10],
-                        bitwidth: IntegerWidth::Eight,
-                    },
+                    ByteString::new(
+                        vec![0, 1, 2, 3, 4]
+                    ).with_bitwidth(IntegerWidth::Zero),
+                    ByteString::new(
+                        vec![5, 6, 7, 8, 9, 10]
+                    ).with_bitwidth(IntegerWidth::Eight),
                 ]),
                 indoc!(r#"
                     5f                 # bytes(*)
@@ -480,14 +424,10 @@ testcases! {
 
             escaped(hex2value, value2hex) {
                 DataItem::IndefiniteByteString(vec![
-                    ByteString {
-                        data: b"\\"[..].into(),
-                        bitwidth: IntegerWidth::Zero,
-                    },
-                    ByteString {
-                        data: b"\""[..].into(),
-                        bitwidth: IntegerWidth::Eight,
-                    },
+                    ByteString::new(*b"\\")
+                        .with_bitwidth(IntegerWidth::Zero),
+                    ByteString::new(*b"\"")
+                        .with_bitwidth(IntegerWidth::Eight),
                 ]),
                 indoc!(r#"
                     5f       # bytes(*)
@@ -503,93 +443,82 @@ testcases! {
 
     mod encodings {
         base16(diag2value) {
-            DataItem::ByteString(ByteString {
-                data: hex!("12345678").into(),
-                bitwidth: IntegerWidth::Unknown,
-            }),
+            DataItem::ByteString(ByteString::new(
+                hex!("12345678")
+            )),
             { "h'12345678'" }
         }
 
         base32(diag2value) {
-            DataItem::ByteString(ByteString {
-                data: hex!("12345678").into(),
-                bitwidth: IntegerWidth::Unknown,
-            }),
+            DataItem::ByteString(ByteString::new(
+                hex!("12345678")
+            )),
             { "b32'CI2FM6A='" }
         }
 
         base32hex(diag2value) {
-            DataItem::ByteString(ByteString {
-                data: hex!("12345678").into(),
-                bitwidth: IntegerWidth::Unknown,
-            }),
+            DataItem::ByteString(ByteString::new(
+                hex!("12345678")
+            )),
             { "h32'28Q5CU0='" }
         }
 
         base64(diag2value) {
-            DataItem::ByteString(ByteString {
-                data: hex!("12345678").into(),
-                bitwidth: IntegerWidth::Unknown,
-            }),
+            DataItem::ByteString(ByteString::new(
+                hex!("12345678")
+            )),
             { "b64'EjRWeA=='" }
         }
 
         base64url(diag2value) {
-            DataItem::ByteString(ByteString {
-                data: hex!("12345678").into(),
-                bitwidth: IntegerWidth::Unknown,
-            }),
+            DataItem::ByteString(ByteString::new(
+                hex!("12345678")
+            )),
             { "b64'EjRWeA'" }
         }
 
         // RFC 8610 Appendix G.2
         utf8(diag2value) {
-            DataItem::ByteString(ByteString {
-                data: Vec::from(*b"'Hello Ferris!'"),
-                bitwidth: IntegerWidth::Unknown,
-            }),
+            DataItem::ByteString(ByteString::new(
+                *b"'Hello Ferris!'"
+            )),
             { r#"'\'Hello Ferris!\''"# }
         }
 
         // RFC 8610 Appendix G.1
         mod whitespace {
             base16(diag2value) {
-                DataItem::ByteString(ByteString {
-                    data: hex!("12345678").into(),
-                    bitwidth: IntegerWidth::Unknown,
-                }),
+                DataItem::ByteString(ByteString::new(
+                    hex!("12345678")
+                )),
                 { "h'12 34\t56\n78'" }
             }
 
             base32(diag2value) {
-                DataItem::ByteString(ByteString {
-                    data: hex!("12345678").into(),
-                    bitwidth: IntegerWidth::Unknown,
-                }),
+                DataItem::ByteString(ByteString::new(
+                    hex!("12345678")
+                )),
                 { "b32'CI 2F\tM6A\n='" }
             }
 
             base32hex(diag2value) {
-                DataItem::ByteString(ByteString {
-                    data: hex!("12345678").into(),
-                    bitwidth: IntegerWidth::Unknown,
-                }),
+                DataItem::ByteString(ByteString::new(
+                    hex!("12345678")
+                )),
                 { "h32'28 Q5\tCU0\n='" }
             }
 
             base64(diag2value) {
-                DataItem::ByteString(ByteString {
-                    data: hex!("12345678").into(),
-                    bitwidth: IntegerWidth::Unknown,
-                }),
+                DataItem::ByteString(ByteString::new(
+                    hex!("12345678")
+                )),
                 { "b64'Ej RW\teA\n=='" }
             }
 
             base64url(diag2value) {
-                DataItem::ByteString(ByteString {
-                    data: hex!("12345678").into(),
-                    bitwidth: IntegerWidth::Unknown,
-                }),
+                DataItem::ByteString(ByteString::new(
+                    hex!("12345678")
+                )),
                 { "b64'Ej RW\teA\n'" }
             }
         }
@@ -598,42 +527,37 @@ testcases! {
     // RFC 8610 Appendix G.4
     mod concatenated {
         one(diag2value) {
-            DataItem::ByteString(ByteString {
-                data: Vec::from(*b"Hello Ferris!"),
-                bitwidth: IntegerWidth::Unknown,
-            }),
+            DataItem::ByteString(ByteString::new(
+                "Hello Ferris!"
+            )),
             { "'Hello ' 'Ferris!'" }
         }
 
         two(diag2value) {
-            DataItem::ByteString(ByteString {
-                data: Vec::from(*b"Hello Ferris!"),
-                bitwidth: IntegerWidth::Unknown,
-            }),
+            DataItem::ByteString(ByteString::new(
+                "Hello Ferris!"
+            )),
             { "'Hello ' h'46657272697321'" }
         }
 
         three(diag2value) {
-            DataItem::ByteString(ByteString {
-                data: Vec::from(*b"Hello Ferris!"),
-                bitwidth: IntegerWidth::Unknown,
-            }),
+            DataItem::ByteString(ByteString::new(
+                "Hello Ferris!"
+            )),
             { "'Hello' h'20' 'Ferris!'" }
         }
 
         four(diag2value) {
-            DataItem::ByteString(ByteString {
-                data: Vec::from(*b"Hello Ferris!"),
-                bitwidth: IntegerWidth::Unknown,
-            }),
+            DataItem::ByteString(ByteString::new(
+                "Hello Ferris!"
+            )),
             { "'' h'48656c6c6f2046657272697321' '' b64''" }
         }
 
         five(diag2value) {
-            DataItem::ByteString(ByteString {
-                data: Vec::from(*b"Hello Ferris!"),
-                bitwidth: IntegerWidth::Unknown,
-            }),
+            DataItem::ByteString(ByteString::new(
+                "Hello Ferris!"
+            )),
             { "h'4 86 56c 6c6f' h' 20466 57272697321'" }
         }
     }
@@ -641,50 +565,44 @@ testcases! {
     // RFC 8610 Appendix G.3
     mod embedded {
         one(diag2value) {
-            DataItem::ByteString(ByteString {
-                data: hex!("01").into(),
-                bitwidth: IntegerWidth::Unknown,
-            }),
+            DataItem::ByteString(ByteString::new(
+                hex!("01")
+            )),
             { "<<1>>" }
         }
 
         two(diag2value) {
-            DataItem::ByteString(ByteString {
-                data: hex!("0102").into(),
-                bitwidth: IntegerWidth::Unknown,
-            }),
+            DataItem::ByteString(ByteString::new(
+                hex!("0102")
+            )),
             { "<<1, 2>>" }
         }
 
         foo(diag2value) {
-            DataItem::ByteString(ByteString {
-                data: hex!("63666f6ff6").into(),
-                bitwidth: IntegerWidth::Unknown,
-            }),
+            DataItem::ByteString(ByteString::new(
+                hex!("63666f6ff6")
+            )),
             { r#"<<"foo", null>>"# }
         }
 
         empty(diag2value) {
-            DataItem::ByteString(ByteString {
-                data: vec![],
-                bitwidth: IntegerWidth::Unknown,
-            }),
+            DataItem::ByteString(ByteString::new(
+                vec![]
+            )),
             { "<<>>" }
         }
 
         nested(diag2value) {
-            DataItem::ByteString(ByteString {
-                data: hex!("63666f6ff6420102").into(),
-                bitwidth: IntegerWidth::Unknown,
-            }),
+            DataItem::ByteString(ByteString::new(
+                hex!("63666f6ff6420102")
+            )),
             { r#"<<"foo", null, <<1, 2>>>>"# }
         }
 
         concatenated(diag2value) {
-            DataItem::ByteString(ByteString {
-                data: hex!("48656c6c6f4746657272697321").into(),
-                bitwidth: IntegerWidth::Unknown,
-            }),
+            DataItem::ByteString(ByteString::new(
+                hex!("48656c6c6f4746657272697321")
+            )),
             { "'Hello' <<'Ferris!'>>" }
         }
     }

--- a/tests/comments.rs
+++ b/tests/comments.rs
@@ -53,10 +53,9 @@ testcases! {
     }
 
     rfc_bytestring(diag2value) {
-        DataItem::ByteString(ByteString {
-            data: hex!("68656c6c6f20776f726c64").into(),
-            bitwidth: IntegerWidth::Unknown,
-        }),
+        DataItem::ByteString(ByteString::new(
+            hex!("68656c6c6f20776f726c64"))
+        ),
         {
             "
                 h'68 65 6c /doubled l!/ 6c 6f /hello/
@@ -67,10 +66,9 @@ testcases! {
     }
 
     not_unprefixed_bytestrings(diag2value) {
-        DataItem::ByteString(ByteString {
-            data: b"hello /world/"[..].into(),
-            bitwidth: IntegerWidth::Unknown,
-        }),
+        DataItem::ByteString(ByteString::new(
+            *b"hello /world/")
+        ),
         {
             "
                 'hello /world/'

--- a/tests/issues.rs
+++ b/tests/issues.rs
@@ -14,10 +14,7 @@ testcases! {
                         bitwidth: IntegerWidth::Zero,
                     },
                     DataItem::ByteString(
-                        ByteString {
-                            data: hex!("0128bf0000002c").into(),
-                            bitwidth: IntegerWidth::Unknown,
-                        },
+                        ByteString::new(hex!("0128bf0000002c"))
                     ),
                 ),
                 (

--- a/tests/map.rs
+++ b/tests/map.rs
@@ -103,10 +103,9 @@ testcases! {
                                         ],
                                         bitwidth: Some(IntegerWidth::Unknown),
                                     },
-                                    DataItem::ByteString(ByteString {
-                                        data: "\u{1f1f3}".into(),
-                                        bitwidth: IntegerWidth::Unknown,
-                                    }),
+                                    DataItem::ByteString(ByteString::new(
+                                            "\u{1f1f3}")
+                                    ),
                                 )
                             ],
                             bitwidth: Some(IntegerWidth::Unknown),
@@ -266,10 +265,9 @@ testcases! {
                                         ],
                                         bitwidth: Some(IntegerWidth::Zero),
                                     },
-                                    DataItem::ByteString(ByteString {
-                                        data: "\u{1f1f3}".into(),
-                                        bitwidth: IntegerWidth::Zero,
-                                    }),
+                                    DataItem::ByteString(ByteString::new(
+                                        "\u{1f1f3}").with_bitwidth(IntegerWidth::Zero)
+                                    ),
                                 )
                             ],
                             bitwidth: Some(IntegerWidth::Eight),
@@ -434,10 +432,9 @@ testcases! {
                                             ],
                                             bitwidth: Some(IntegerWidth::Unknown),
                                         },
-                                        DataItem::ByteString(ByteString {
-                                            data: "\u{1f1f3}".into(),
-                                            bitwidth: IntegerWidth::Unknown,
-                                        }),
+                                        DataItem::ByteString(ByteString::new(
+                                            "\u{1f1f3}")
+                                        ),
                                     )
                                 ],
                                 bitwidth: Some(IntegerWidth::Unknown),
@@ -601,10 +598,9 @@ testcases! {
                                             ],
                                             bitwidth: Some(IntegerWidth::Zero),
                                         },
-                                        DataItem::ByteString(ByteString {
-                                            data: "\u{1f1f3}".into(),
-                                            bitwidth: IntegerWidth::Zero,
-                                        }),
+                                        DataItem::ByteString(ByteString::new(
+                                            "\u{1f1f3}").with_bitwidth(IntegerWidth::Zero)
+                                        ),
                                     )
                                 ],
                                 bitwidth: Some(IntegerWidth::Eight),

--- a/tests/proptest.rs
+++ b/tests/proptest.rs
@@ -63,7 +63,7 @@ fn arb_bytestring() -> impl Strategy<Value = ByteString> {
             any::<u8>(),
             0..=cmp::min(bitwidth_max(bitwidth) as usize, 300),
         )
-        .prop_map(move |data| ByteString { data, bitwidth })
+        .prop_map(move |data| ByteString::new(data).with_bitwidth(bitwidth))
     })
 }
 

--- a/tests/tags.rs
+++ b/tests/tags.rs
@@ -236,25 +236,22 @@ testcases! {
             DataItem::Tag {
                 tag: Tag::POSITIVE_BIGNUM,
                 bitwidth: IntegerWidth::Zero,
-                value: Box::new(DataItem::ByteString(ByteString {
-                    data: hex!("000001ffffffffffffffffffffff0000000000000000000000").into(),
-                    bitwidth: IntegerWidth::Unknown,
-                }))
+                value: Box::new(DataItem::ByteString(ByteString::new(
+                    hex!("000001ffffffffffffffffffffff0000000000000000000000"))
+                ))
             },
             {
                 "2(h'000001ffffffffffffffffffffff0000000000000000000000')",
                 "2(h'000001ffffffffffffffffffffff0000000000000000000000')",
             }
         }
-
         negative_bignum(diag2value, value2diag) {
             DataItem::Tag {
                 tag: Tag::NEGATIVE_BIGNUM,
                 bitwidth: IntegerWidth::Zero,
-                value: Box::new(DataItem::ByteString(ByteString {
-                    data: hex!("123456789abcdeffedcba987654321").into(),
-                    bitwidth: IntegerWidth::Unknown,
-                }))
+                value: Box::new(DataItem::ByteString(ByteString::new(
+                    hex!("123456789abcdeffedcba987654321"))
+                ))
             },
             {
                 "3(h'123456789abcdeffedcba987654321')",
@@ -323,10 +320,9 @@ testcases! {
                         DataItem::Tag {
                             tag: Tag::POSITIVE_BIGNUM,
                             bitwidth: IntegerWidth::Zero,
-                            value: Box::new(DataItem::ByteString(ByteString {
-                                data: hex!("000001ffffffffffffffffffffff0000000000000000000000").into(),
-                                bitwidth: IntegerWidth::Unknown,
-                            })),
+                            value: Box::new(DataItem::ByteString(ByteString::new(
+                                hex!("000001ffffffffffffffffffffff0000000000000000000000"))
+                            )),
                         },
                     ],
                     bitwidth: Some(IntegerWidth::Unknown),
@@ -356,10 +352,9 @@ testcases! {
                         DataItem::Tag {
                             tag: Tag::POSITIVE_BIGNUM,
                             bitwidth: IntegerWidth::Zero,
-                            value: Box::new(DataItem::ByteString(ByteString {
-                                data: hex!("000001ffffffffffffffffffffff0000000000000000000000").into(),
-                                bitwidth: IntegerWidth::Unknown,
-                            })),
+                            value: Box::new(DataItem::ByteString(ByteString::new(
+                                hex!("000001ffffffffffffffffffffff0000000000000000000000"))
+                            )),
                         },
                     ],
                     bitwidth: Some(IntegerWidth::Unknown),
@@ -380,10 +375,9 @@ testcases! {
             DataItem::Tag {
                 tag: Tag::ENCODED_BASE64URL,
                 bitwidth: IntegerWidth::Zero,
-                value: Box::new(DataItem::ByteString(ByteString {
-                    data: hex!("123456789abcdeffedcba9876543").into(),
-                    bitwidth: IntegerWidth::Unknown,
-                })),
+                value: Box::new(DataItem::ByteString(ByteString::new(
+                    hex!("123456789abcdeffedcba9876543"))
+                )),
             },
             {
                 "21(b64'EjRWeJq83v_ty6mHZUM')",
@@ -395,10 +389,9 @@ testcases! {
             DataItem::Tag {
                 tag: Tag::ENCODED_BASE64URL,
                 bitwidth: IntegerWidth::Zero,
-                value: Box::new(DataItem::ByteString(ByteString {
-                    data: hex!("12").into(),
-                    bitwidth: IntegerWidth::Unknown,
-                })),
+                value: Box::new(DataItem::ByteString(ByteString::new(
+                    hex!("12"))
+                )),
             },
             {
                 "21(b64'Eg')",
@@ -412,10 +405,9 @@ testcases! {
                 bitwidth: IntegerWidth::Zero,
                 value: Box::new(DataItem::Array {
                     data: vec![
-                        DataItem::ByteString(ByteString {
-                            data: hex!("123456789abcdeffedcba9876543").into(),
-                            bitwidth: IntegerWidth::Unknown,
-                        }),
+                        DataItem::ByteString(ByteString::new(
+                            hex!("123456789abcdeffedcba9876543"))
+                        ),
                     ],
                     bitwidth: None,
                 })
@@ -430,10 +422,9 @@ testcases! {
             DataItem::Tag {
                 tag: Tag::ENCODED_BASE64,
                 bitwidth: IntegerWidth::Zero,
-                value: Box::new(DataItem::ByteString(ByteString {
-                    data: hex!("123456789abcdeffedcba9876543").into(),
-                    bitwidth: IntegerWidth::Unknown,
-                })),
+                value: Box::new(DataItem::ByteString(ByteString::new(
+                    hex!("123456789abcdeffedcba9876543"))
+                )),
             },
             {
                 "22(b64'EjRWeJq83v/ty6mHZUM=')",
@@ -445,10 +436,9 @@ testcases! {
             DataItem::Tag {
                 tag: Tag::ENCODED_BASE64,
                 bitwidth: IntegerWidth::Zero,
-                value: Box::new(DataItem::ByteString(ByteString {
-                    data: hex!("12").into(),
-                    bitwidth: IntegerWidth::Unknown,
-                })),
+                value: Box::new(DataItem::ByteString(ByteString::new(
+                    hex!("12"))
+                )),
             },
             {
                 "22(b64'Eg==')",
@@ -462,10 +452,9 @@ testcases! {
                 bitwidth: IntegerWidth::Zero,
                 value: Box::new(DataItem::Array {
                     data: vec![
-                        DataItem::ByteString(ByteString {
-                            data: hex!("123456789abcdeffedcba9876543").into(),
-                            bitwidth: IntegerWidth::Unknown,
-                        }),
+                        DataItem::ByteString(ByteString::new(
+                            hex!("123456789abcdeffedcba9876543"))
+                        ),
                     ],
                     bitwidth: None,
                 })
@@ -480,10 +469,9 @@ testcases! {
             DataItem::Tag {
                 tag: Tag::ENCODED_BASE16,
                 bitwidth: IntegerWidth::Zero,
-                value: Box::new(DataItem::ByteString(ByteString {
-                    data: hex!("123456789abcdeffedcba9876543").into(),
-                    bitwidth: IntegerWidth::Unknown,
-                })),
+                value: Box::new(DataItem::ByteString(ByteString::new(
+                    hex!("123456789abcdeffedcba9876543"))
+                )),
             },
             {
                 "23(h'123456789abcdeffedcba9876543')",
@@ -497,10 +485,9 @@ testcases! {
                 bitwidth: IntegerWidth::Zero,
                 value: Box::new(DataItem::Array {
                     data: vec![
-                        DataItem::ByteString(ByteString {
-                            data: hex!("123456789abcdeffedcba9876543").into(),
-                            bitwidth: IntegerWidth::Unknown,
-                        }),
+                        DataItem::ByteString(ByteString::new(
+                            hex!("123456789abcdeffedcba9876543"))
+                        ),
                     ],
                     bitwidth: None,
                 })
@@ -517,19 +504,17 @@ testcases! {
                 bitwidth: IntegerWidth::Zero,
                 value: Box::new(DataItem::Array {
                     data: vec![
-                        DataItem::ByteString(ByteString {
-                            data: hex!("123456789abcdeffedcba9876543").into(),
-                            bitwidth: IntegerWidth::Unknown,
-                        }),
+                        DataItem::ByteString(ByteString::new(
+                            hex!("123456789abcdeffedcba9876543"))
+                        ),
                         DataItem::Tag {
                             tag: Tag::ENCODED_BASE64,
                             bitwidth: IntegerWidth::Zero,
                             value: Box::new(DataItem::Array {
                                 data: vec![
-                                    DataItem::ByteString(ByteString {
-                                        data: hex!("123456789abcdeffedcba9876543").into(),
-                                        bitwidth: IntegerWidth::Unknown,
-                                    })
+                                    DataItem::ByteString(ByteString::new(
+                                        hex!("123456789abcdeffedcba9876543"))
+                                    )
                                 ],
                                 bitwidth: None,
                             })
@@ -537,10 +522,9 @@ testcases! {
                         DataItem::Tag {
                             tag: Tag::ENCODED_BASE16,
                             bitwidth: IntegerWidth::Zero,
-                            value: Box::new(DataItem::ByteString(ByteString {
-                                data: hex!("123456789abcdeffedcba9876543").into(),
-                                bitwidth: IntegerWidth::Unknown,
-                            })),
+                            value: Box::new(DataItem::ByteString(ByteString::new(
+                                hex!("123456789abcdeffedcba9876543"))
+                            )),
                         },
                     ],
                     bitwidth: None,
@@ -562,10 +546,9 @@ testcases! {
             DataItem::Tag {
                 tag: Tag::ENCODED_CBOR,
                 bitwidth: IntegerWidth::Unknown,
-                value: Box::new(DataItem::ByteString(ByteString {
-                    data: hex!("9f64f09f87b317ff").into(),
-                    bitwidth: IntegerWidth::Unknown,
-                })),
+                value: Box::new(DataItem::ByteString(ByteString::new(
+                    hex!("9f64f09f87b317ff"))
+                )),
             },
             {
                 r#"24(<<[_"🇳",23]>>)"#,
@@ -577,10 +560,9 @@ testcases! {
             DataItem::Tag {
                 tag: Tag::ENCODED_CBOR,
                 bitwidth: IntegerWidth::Unknown,
-                value: Box::new(DataItem::ByteString(ByteString {
-                    data: hex!("ff").into(),
-                    bitwidth: IntegerWidth::Unknown,
-                })),
+                value: Box::new(DataItem::ByteString(ByteString::new(
+                    hex!("ff"))
+                )),
             },
             {
                 "24(h'ff')",
@@ -592,10 +574,9 @@ testcases! {
             DataItem::Tag {
                 tag: Tag::ENCODED_CBOR,
                 bitwidth: IntegerWidth::Unknown,
-                value: Box::new(DataItem::ByteString(ByteString {
-                    data: hex!("d818489f64f09f87b317ff").into(),
-                    bitwidth: IntegerWidth::Unknown,
-                })),
+                value: Box::new(DataItem::ByteString(ByteString::new(
+                    hex!("d818489f64f09f87b317ff"))
+                )),
             },
             {
                 r#"24(<<24_0(<<[_"🇳",23]>>)>>)"#,
@@ -607,10 +588,10 @@ testcases! {
             DataItem::Tag {
                 tag: Tag::ENCODED_CBOR,
                 bitwidth: IntegerWidth::Unknown,
-                value: Box::new(DataItem::ByteString(ByteString {
-                    data: vec![],
-                    bitwidth: IntegerWidth::Unknown,
-                })),
+                value: Box::new(DataItem::ByteString(ByteString::new(
+                            vec![]
+                   )
+                )),
             },
             {
                 r#"24(<<>>)"#,
@@ -622,10 +603,9 @@ testcases! {
             DataItem::Tag {
                 tag: Tag::ENCODED_CBOR_SEQ,
                 bitwidth: IntegerWidth::Unknown,
-                value: Box::new(DataItem::ByteString(ByteString {
-                    data: hex!("9f64f09f87b317ff1615").into(),
-                    bitwidth: IntegerWidth::Unknown,
-                })),
+                value: Box::new(DataItem::ByteString(ByteString::new(
+                    hex!("9f64f09f87b317ff1615"))
+                )),
             },
             {
                 r#"63(<<[_"🇳",23],22,21>>)"#,
@@ -637,10 +617,9 @@ testcases! {
             DataItem::Tag {
                 tag: Tag::ENCODED_CBOR_SEQ,
                 bitwidth: IntegerWidth::Unknown,
-                value: Box::new(DataItem::ByteString(ByteString {
-                    data: hex!("1617ff").into(),
-                    bitwidth: IntegerWidth::Unknown,
-                })),
+                value: Box::new(DataItem::ByteString(ByteString::new(
+                    hex!("1617ff"))
+                )),
             },
             {
                 "63(<<22,23>>h'ff')",
@@ -652,10 +631,10 @@ testcases! {
             DataItem::Tag {
                 tag: Tag::ENCODED_CBOR_SEQ,
                 bitwidth: IntegerWidth::Unknown,
-                value: Box::new(DataItem::ByteString(ByteString {
-                    data: vec![],
-                    bitwidth: IntegerWidth::Unknown,
-                })),
+                value: Box::new(DataItem::ByteString(ByteString::new(
+                            vec![]
+                   )
+                )),
             },
             {
                 "63(<<>>)",
@@ -880,10 +859,10 @@ testcases! {
             DataItem::Tag {
                 tag: Tag::POSITIVE_BIGNUM,
                 bitwidth: IntegerWidth::Zero,
-                value: Box::new(DataItem::ByteString(ByteString {
-                    data: hex!("000001ffffffffffffffffffffff0000000000000000000000").into(),
-                    bitwidth: IntegerWidth::Eight,
-                }))
+                value: Box::new(DataItem::ByteString(ByteString::new(
+                    hex!("000001ffffffffffffffffffffff0000000000000000000000"))
+                    .with_bitwidth(IntegerWidth::Eight)
+                ))
             },
             indoc!(r#"
                 c2                                     # positive bignum, tag(2)
@@ -898,10 +877,10 @@ testcases! {
             DataItem::Tag {
                 tag: Tag::NEGATIVE_BIGNUM,
                 bitwidth: IntegerWidth::Zero,
-                value: Box::new(DataItem::ByteString(ByteString {
-                    data: hex!("123456789abcdeffedcba987654321").into(),
-                    bitwidth: IntegerWidth::Eight,
-                }))
+                value: Box::new(DataItem::ByteString(ByteString::new(
+                    hex!("123456789abcdeffedcba987654321"))
+                    .with_bitwidth(IntegerWidth::Eight)
+                ))
             },
             indoc!(r#"
                 c3                                   # negative bignum, tag(3)
@@ -978,10 +957,10 @@ testcases! {
                         DataItem::Tag {
                             tag: Tag::POSITIVE_BIGNUM,
                             bitwidth: IntegerWidth::Zero,
-                            value: Box::new(DataItem::ByteString(ByteString {
-                                data: hex!("000001ffffffffffffffffffffff0000000000000000000000").into(),
-                                bitwidth: IntegerWidth::Eight,
-                            }))
+                            value: Box::new(DataItem::ByteString(ByteString::new(
+                                hex!("000001ffffffffffffffffffffff0000000000000000000000"))
+                                .with_bitwidth(IntegerWidth::Eight)
+                            ))
                         },
                     ],
                     bitwidth: Some(IntegerWidth::Zero),
@@ -1013,10 +992,10 @@ testcases! {
                         DataItem::Tag {
                             tag: Tag::POSITIVE_BIGNUM,
                             bitwidth: IntegerWidth::Zero,
-                            value: Box::new(DataItem::ByteString(ByteString {
-                                data: hex!("000001ffffffffffffffffffffff0000000000000000000000").into(),
-                                bitwidth: IntegerWidth::Eight,
-                            }))
+                            value: Box::new(DataItem::ByteString(ByteString::new(
+                                hex!("000001ffffffffffffffffffffff0000000000000000000000"))
+                                .with_bitwidth(IntegerWidth::Eight)
+                            ))
                         },
                     ],
                     bitwidth: Some(IntegerWidth::Zero),
@@ -1039,10 +1018,10 @@ testcases! {
             DataItem::Tag {
                 tag: Tag::ENCODED_BASE64URL,
                 bitwidth: IntegerWidth::Zero,
-                value: Box::new(DataItem::ByteString(ByteString {
-                    data: hex!("123456789abcdeffedcba9876543").into(),
-                    bitwidth: IntegerWidth::Zero,
-                })),
+                value: Box::new(DataItem::ByteString(ByteString::new(
+                    hex!("123456789abcdeffedcba9876543"))
+                    .with_bitwidth(IntegerWidth::Zero)
+                )),
             },
             indoc!(r#"
                 d5                                 # suggested base64url encoding, tag(21)
@@ -1057,10 +1036,10 @@ testcases! {
                 bitwidth: IntegerWidth::Zero,
                 value: Box::new(DataItem::Array {
                     data: vec![
-                        DataItem::ByteString(ByteString {
-                            data: hex!("123456789abcdeffedcba9876543").into(),
-                            bitwidth: IntegerWidth::Zero,
-                        }),
+                        DataItem::ByteString(ByteString::new(
+                            hex!("123456789abcdeffedcba9876543"))
+                        .with_bitwidth(IntegerWidth::Zero)
+                        ),
                     ],
                     bitwidth: None,
                 })
@@ -1078,10 +1057,10 @@ testcases! {
             DataItem::Tag {
                 tag: Tag::ENCODED_BASE64,
                 bitwidth: IntegerWidth::Zero,
-                value: Box::new(DataItem::ByteString(ByteString {
-                    data: hex!("123456789abcdeffedcba9876543").into(),
-                    bitwidth: IntegerWidth::Zero,
-                })),
+                value: Box::new(DataItem::ByteString(ByteString::new(
+                    hex!("123456789abcdeffedcba9876543"))
+                    .with_bitwidth(IntegerWidth::Zero)
+                )),
             },
             indoc!(r#"
                 d6                                 # suggested base64 encoding, tag(22)
@@ -1096,10 +1075,10 @@ testcases! {
                 bitwidth: IntegerWidth::Zero,
                 value: Box::new(DataItem::Array {
                     data: vec![
-                        DataItem::ByteString(ByteString {
-                            data: hex!("123456789abcdeffedcba9876543").into(),
-                            bitwidth: IntegerWidth::Zero,
-                        }),
+                        DataItem::ByteString(ByteString::new(
+                            hex!("123456789abcdeffedcba9876543"))
+                        .with_bitwidth(IntegerWidth::Zero)
+                        ),
                     ],
                     bitwidth: None,
                 })
@@ -1117,10 +1096,10 @@ testcases! {
             DataItem::Tag {
                 tag: Tag::ENCODED_BASE16,
                 bitwidth: IntegerWidth::Zero,
-                value: Box::new(DataItem::ByteString(ByteString {
-                    data: hex!("123456789abcdeffedcba9876543").into(),
-                    bitwidth: IntegerWidth::Zero,
-                })),
+                value: Box::new(DataItem::ByteString(ByteString::new(
+                    hex!("123456789abcdeffedcba9876543"))
+                    .with_bitwidth(IntegerWidth::Zero)
+                )),
             },
             indoc!(r#"
                 d7                                 # suggested base16 encoding, tag(23)
@@ -1135,10 +1114,10 @@ testcases! {
                 bitwidth: IntegerWidth::Zero,
                 value: Box::new(DataItem::Array {
                     data: vec![
-                        DataItem::ByteString(ByteString {
-                            data: hex!("123456789abcdeffedcba9876543").into(),
-                            bitwidth: IntegerWidth::Zero,
-                        }),
+                        DataItem::ByteString(ByteString::new(
+                            hex!("123456789abcdeffedcba9876543"))
+                        .with_bitwidth(IntegerWidth::Zero)
+                        ),
                     ],
                     bitwidth: None,
                 })
@@ -1158,19 +1137,19 @@ testcases! {
                 bitwidth: IntegerWidth::Zero,
                 value: Box::new(DataItem::Array {
                     data: vec![
-                        DataItem::ByteString(ByteString {
-                            data: hex!("123456789abcdeffedcba9876543").into(),
-                            bitwidth: IntegerWidth::Zero,
-                        }),
+                        DataItem::ByteString(ByteString::new(
+                            hex!("123456789abcdeffedcba9876543"))
+                        .with_bitwidth(IntegerWidth::Zero)
+                        ),
                         DataItem::Tag {
                             tag: Tag::ENCODED_BASE64,
                             bitwidth: IntegerWidth::Zero,
                             value: Box::new(DataItem::Array {
                                 data: vec![
-                                    DataItem::ByteString(ByteString {
-                                        data: hex!("123456789abcdeffedcba9876543").into(),
-                                        bitwidth: IntegerWidth::Zero,
-                                    })
+                                    DataItem::ByteString(ByteString::new(
+                                        hex!("123456789abcdeffedcba9876543"))
+                                    .with_bitwidth(IntegerWidth::Zero)
+                                    )
                                 ],
                                 bitwidth: None,
                             })
@@ -1178,10 +1157,10 @@ testcases! {
                         DataItem::Tag {
                             tag: Tag::ENCODED_BASE16,
                             bitwidth: IntegerWidth::Zero,
-                            value: Box::new(DataItem::ByteString(ByteString {
-                                data: hex!("123456789abcdeffedcba9876543").into(),
-                                bitwidth: IntegerWidth::Zero,
-                            })),
+                            value: Box::new(DataItem::ByteString(ByteString::new(
+                                hex!("123456789abcdeffedcba9876543"))
+                                .with_bitwidth(IntegerWidth::Zero)
+                            )),
                         },
                     ],
                     bitwidth: None,
@@ -1208,10 +1187,10 @@ testcases! {
             DataItem::Tag {
                 tag: Tag::ENCODED_CBOR,
                 bitwidth: IntegerWidth::Eight,
-                value: Box::new(DataItem::ByteString(ByteString {
-                    data: hex!("9f64f09f87b317ff").into(),
-                    bitwidth: IntegerWidth::Zero,
-                })),
+                value: Box::new(DataItem::ByteString(ByteString::new(
+                    hex!("9f64f09f87b317ff"))
+                    .with_bitwidth(IntegerWidth::Zero)
+                )),
             },
             indoc!("
                 d8 18                  # encoded cbor data item, tag(24)
@@ -1230,10 +1209,10 @@ testcases! {
             DataItem::Tag {
                 tag: Tag::ENCODED_CBOR,
                 bitwidth: IntegerWidth::Eight,
-                value: Box::new(DataItem::ByteString(ByteString {
-                    data: hex!("ff").into(),
-                    bitwidth: IntegerWidth::Zero,
-                })),
+                value: Box::new(DataItem::ByteString(ByteString::new(
+                    hex!("ff"))
+                    .with_bitwidth(IntegerWidth::Zero)
+                )),
             },
             indoc!(r#"
                 d8 18    # encoded cbor data item, tag(24)
@@ -1248,10 +1227,11 @@ testcases! {
             DataItem::Tag {
                 tag: Tag::ENCODED_CBOR,
                 bitwidth: IntegerWidth::Eight,
-                value: Box::new(DataItem::ByteString(ByteString {
-                    data: vec![],
-                    bitwidth: IntegerWidth::Zero,
-                })),
+                value: Box::new(DataItem::ByteString(ByteString::new(
+                            vec![]
+                   )
+                    .with_bitwidth(IntegerWidth::Zero)
+                )),
             },
             indoc!(r#"
                 d8 18 # encoded cbor data item, tag(24)
@@ -1266,10 +1246,10 @@ testcases! {
             DataItem::Tag {
                 tag: Tag::ENCODED_CBOR_SEQ,
                 bitwidth: IntegerWidth::Eight,
-                value: Box::new(DataItem::ByteString(ByteString {
-                    data: hex!("9f64f09f87b317ff1615").into(),
-                    bitwidth: IntegerWidth::Zero,
-                })),
+                value: Box::new(DataItem::ByteString(ByteString::new(
+                    hex!("9f64f09f87b317ff1615"))
+                    .with_bitwidth(IntegerWidth::Zero)
+                )),
             },
             indoc!(r#"
                 d8 3f                      # encoded cbor sequence, tag(63)
@@ -1292,10 +1272,10 @@ testcases! {
             DataItem::Tag {
                 tag: Tag::ENCODED_CBOR_SEQ,
                 bitwidth: IntegerWidth::Eight,
-                value: Box::new(DataItem::ByteString(ByteString {
-                    data: hex!("1617ff").into(),
-                    bitwidth: IntegerWidth::Zero,
-                })),
+                value: Box::new(DataItem::ByteString(ByteString::new(
+                    hex!("1617ff"))
+                    .with_bitwidth(IntegerWidth::Zero)
+                )),
             },
             indoc!(r#"
                 d8 3f        # encoded cbor sequence, tag(63)
@@ -1314,10 +1294,11 @@ testcases! {
             DataItem::Tag {
                 tag: Tag::ENCODED_CBOR_SEQ,
                 bitwidth: IntegerWidth::Eight,
-                value: Box::new(DataItem::ByteString(ByteString {
-                    data: vec![],
-                    bitwidth: IntegerWidth::Zero,
-                })),
+                value: Box::new(DataItem::ByteString(ByteString::new(
+                            vec![]
+                   )
+                    .with_bitwidth(IntegerWidth::Zero)
+                )),
             },
             indoc!(r#"
                 d8 3f # encoded cbor sequence, tag(63)
@@ -1424,10 +1405,10 @@ testcases! {
             DataItem::Tag {
                 tag: Tag::ENCODED_CBOR,
                 bitwidth: IntegerWidth::Eight,
-                value: Box::new(DataItem::ByteString(ByteString {
-                    data: hex!("d818489f64f09f87b317ff").into(),
-                    bitwidth: IntegerWidth::Zero,
-                })),
+                value: Box::new(DataItem::ByteString(ByteString::new(
+                    hex!("d818489f64f09f87b317ff"))
+                    .with_bitwidth(IntegerWidth::Zero)
+                )),
             },
             indoc!("
                 d8 18                        # encoded cbor data item, tag(24)
@@ -1450,10 +1431,10 @@ testcases! {
             DataItem::Tag {
                 tag: Tag::UUID,
                 bitwidth: IntegerWidth::Eight,
-                value: Box::new(DataItem::ByteString(ByteString {
-                    data: hex!("8c8a8d48c00f42209cf8b75a882bf586").into(),
-                    bitwidth: IntegerWidth::Zero,
-                })),
+                value: Box::new(DataItem::ByteString(ByteString::new(
+                    hex!("8c8a8d48c00f42209cf8b75a882bf586"))
+                    .with_bitwidth(IntegerWidth::Zero)
+                )),
             },
             indoc!(r#"
                 d8 25                                  # uuid, tag(37)
@@ -1470,10 +1451,10 @@ testcases! {
             DataItem::Tag {
                 tag: Tag::UUID,
                 bitwidth: IntegerWidth::Eight,
-                value: Box::new(DataItem::ByteString(ByteString {
-                    data: hex!("0123456789").into(),
-                    bitwidth: IntegerWidth::Zero,
-                })),
+                value: Box::new(DataItem::ByteString(ByteString::new(
+                    hex!("0123456789"))
+                    .with_bitwidth(IntegerWidth::Zero)
+                )),
             },
             indoc!(r#"
                 d8 25            # uuid, tag(37)
@@ -1504,10 +1485,10 @@ testcases! {
             DataItem::Tag {
                 tag: Tag::NETWORK_ADDRESS,
                 bitwidth: IntegerWidth::Sixteen,
-                value: Box::new(DataItem::ByteString(ByteString {
-                    data: hex!("c00a0a01").into(),
-                    bitwidth: IntegerWidth::Zero,
-                })),
+                value: Box::new(DataItem::ByteString(ByteString::new(
+                    hex!("c00a0a01"))
+                    .with_bitwidth(IntegerWidth::Zero)
+                )),
             },
             indoc!(r#"
                 d9 0104        # network address, tag(260)
@@ -1521,10 +1502,10 @@ testcases! {
             DataItem::Tag {
                 tag: Tag::NETWORK_ADDRESS,
                 bitwidth: IntegerWidth::Sixteen,
-                value: Box::new(DataItem::ByteString(ByteString {
-                    data: hex!("0123456789ab").into(),
-                    bitwidth: IntegerWidth::Zero,
-                })),
+                value: Box::new(DataItem::ByteString(ByteString::new(
+                    hex!("0123456789ab"))
+                    .with_bitwidth(IntegerWidth::Zero)
+                )),
             },
             indoc!(r#"
                 d9 0104            # network address, tag(260)
@@ -1538,10 +1519,10 @@ testcases! {
             DataItem::Tag {
                 tag: Tag::NETWORK_ADDRESS,
                 bitwidth: IntegerWidth::Sixteen,
-                value: Box::new(DataItem::ByteString(ByteString {
-                    data: hex!("20010db885a3000000008a2e03707334").into(),
-                    bitwidth: IntegerWidth::Zero,
-                })),
+                value: Box::new(DataItem::ByteString(ByteString::new(
+                    hex!("20010db885a3000000008a2e03707334"))
+                    .with_bitwidth(IntegerWidth::Zero)
+                )),
             },
             indoc!(r#"
                 d9 0104                                # network address, tag(260)
@@ -1555,10 +1536,10 @@ testcases! {
             DataItem::Tag {
                 tag: Tag::NETWORK_ADDRESS,
                 bitwidth: IntegerWidth::Sixteen,
-                value: Box::new(DataItem::ByteString(ByteString {
-                    data: hex!("0123456789").into(),
-                    bitwidth: IntegerWidth::Zero,
-                })),
+                value: Box::new(DataItem::ByteString(ByteString::new(
+                    hex!("0123456789"))
+                    .with_bitwidth(IntegerWidth::Zero)
+                )),
             },
             indoc!(r#"
                 d9 0104          # network address, tag(260)
@@ -1745,10 +1726,10 @@ testcases! {
                     DataItem::Tag {
                         tag: Tag::ENCODED_CBOR,
                         bitwidth: IntegerWidth::Eight,
-                        value: Box::new(DataItem::ByteString(ByteString {
-                            data: hex!("d81c00").into(),
-                            bitwidth: IntegerWidth::Zero,
-                        })),
+                        value: Box::new(DataItem::ByteString(ByteString::new(
+                            hex!("d81c00"))
+                            .with_bitwidth(IntegerWidth::Zero)
+                        )),
                     },
                     DataItem::Tag {
                         tag: Tag::SHAREABLE,
@@ -1783,10 +1764,10 @@ testcases! {
             DataItem::Tag {
                 tag: Tag::IPV4,
                 bitwidth: IntegerWidth::Eight,
-                value: Box::new(DataItem::ByteString(ByteString {
-                    data: hex!("c0000201").into(),
-                    bitwidth: IntegerWidth::Zero,
-                })),
+                value: Box::new(DataItem::ByteString(ByteString::new(
+                    hex!("c0000201"))
+                    .with_bitwidth(IntegerWidth::Zero)
+                )),
             },
             indoc!("
                 d8 34          # ipv4 address and/or prefix, tag(52)
@@ -1806,10 +1787,10 @@ testcases! {
                             value: 24,
                             bitwidth: IntegerWidth::Eight,
                         },
-                        DataItem::ByteString(ByteString {
-                            data: hex!("c00002").into(),
-                            bitwidth: IntegerWidth::Zero,
-                        }),
+                        DataItem::ByteString(ByteString::new(
+                            hex!("c00002"))
+                        .with_bitwidth(IntegerWidth::Zero)
+                        ),
                     ],
                     bitwidth: Some(IntegerWidth::Zero),
                 }),
@@ -1830,10 +1811,10 @@ testcases! {
                 bitwidth: IntegerWidth::Eight,
                 value: Box::new(DataItem::Array {
                     data: vec![
-                        DataItem::ByteString(ByteString {
-                            data: hex!("c0000201").into(),
-                            bitwidth: IntegerWidth::Zero,
-                        }),
+                        DataItem::ByteString(ByteString::new(
+                            hex!("c0000201"))
+                        .with_bitwidth(IntegerWidth::Zero)
+                        ),
                         DataItem::Integer {
                             value: 24,
                             bitwidth: IntegerWidth::Eight,
@@ -1858,10 +1839,10 @@ testcases! {
                 bitwidth: IntegerWidth::Eight,
                 value: Box::new(DataItem::Array {
                     data: vec![
-                        DataItem::ByteString(ByteString {
-                            data: hex!("c0000201").into(),
-                            bitwidth: IntegerWidth::Zero,
-                        }),
+                        DataItem::ByteString(ByteString::new(
+                            hex!("c0000201"))
+                        .with_bitwidth(IntegerWidth::Zero)
+                        ),
                         DataItem::Simple(Simple::NULL),
                         DataItem::Integer {
                             value: 6,
@@ -1888,10 +1869,10 @@ testcases! {
                 bitwidth: IntegerWidth::Eight,
                 value: Box::new(DataItem::Array {
                     data: vec![
-                        DataItem::ByteString(ByteString {
-                            data: hex!("c0000201").into(),
-                            bitwidth: IntegerWidth::Zero,
-                        }),
+                        DataItem::ByteString(ByteString::new(
+                            hex!("c0000201"))
+                        .with_bitwidth(IntegerWidth::Zero)
+                        ),
                         DataItem::Simple(Simple::NULL),
                         DataItem::TextString(TextString {
                             data: "eth0".into(),
@@ -1919,10 +1900,10 @@ testcases! {
                 bitwidth: IntegerWidth::Eight,
                 value: Box::new(DataItem::Array {
                     data: vec![
-                        DataItem::ByteString(ByteString {
-                            data: hex!("c0000201").into(),
-                            bitwidth: IntegerWidth::Zero,
-                        }),
+                        DataItem::ByteString(ByteString::new(
+                            hex!("c0000201"))
+                        .with_bitwidth(IntegerWidth::Zero)
+                        ),
                         DataItem::Integer {
                             value: 24,
                             bitwidth: IntegerWidth::Eight,
@@ -1950,10 +1931,10 @@ testcases! {
             DataItem::Tag {
                 tag: Tag::IPV6,
                 bitwidth: IntegerWidth::Eight,
-                value: Box::new(DataItem::ByteString(ByteString {
-                    data: hex!("20010db81234deedbeefcafefacefeed").into(),
-                    bitwidth: IntegerWidth::Zero,
-                })),
+                value: Box::new(DataItem::ByteString(ByteString::new(
+                    hex!("20010db81234deedbeefcafefacefeed"))
+                    .with_bitwidth(IntegerWidth::Zero)
+                )),
             },
             indoc!("
                 d8 36                                  # ipv6 address and/or prefix, tag(54)
@@ -1973,10 +1954,10 @@ testcases! {
                             value: 48,
                             bitwidth: IntegerWidth::Eight,
                         },
-                        DataItem::ByteString(ByteString {
-                            data: hex!("20010db81234").into(),
-                            bitwidth: IntegerWidth::Zero,
-                        }),
+                        DataItem::ByteString(ByteString::new(
+                            hex!("20010db81234"))
+                        .with_bitwidth(IntegerWidth::Zero)
+                        ),
                     ],
                     bitwidth: Some(IntegerWidth::Zero),
                 }),
@@ -1997,10 +1978,10 @@ testcases! {
                 bitwidth: IntegerWidth::Eight,
                 value: Box::new(DataItem::Array {
                     data: vec![
-                        DataItem::ByteString(ByteString {
-                            data: hex!("20010db81234deedbeefcafefacefeed").into(),
-                            bitwidth: IntegerWidth::Zero,
-                        }),
+                        DataItem::ByteString(ByteString::new(
+                            hex!("20010db81234deedbeefcafefacefeed"))
+                        .with_bitwidth(IntegerWidth::Zero)
+                        ),
                         DataItem::Integer {
                             value: 56,
                             bitwidth: IntegerWidth::Eight,
@@ -2025,10 +2006,10 @@ testcases! {
                 bitwidth: IntegerWidth::Eight,
                 value: Box::new(DataItem::Array {
                     data: vec![
-                        DataItem::ByteString(ByteString {
-                            data: hex!("fe8000000000020202fffffffe030303").into(),
-                            bitwidth: IntegerWidth::Zero,
-                        }),
+                        DataItem::ByteString(ByteString::new(
+                            hex!("fe8000000000020202fffffffe030303"))
+                        .with_bitwidth(IntegerWidth::Zero)
+                        ),
                         DataItem::Simple(Simple::NULL),
                         DataItem::Integer {
                             value: 42,
@@ -2055,10 +2036,10 @@ testcases! {
                 bitwidth: IntegerWidth::Eight,
                 value: Box::new(DataItem::Array {
                     data: vec![
-                        DataItem::ByteString(ByteString {
-                            data: hex!("fe8000000000020202fffffffe030303").into(),
-                            bitwidth: IntegerWidth::Zero,
-                        }),
+                        DataItem::ByteString(ByteString::new(
+                            hex!("fe8000000000020202fffffffe030303"))
+                        .with_bitwidth(IntegerWidth::Zero)
+                        ),
                         DataItem::Simple(Simple::NULL),
                         DataItem::TextString(TextString {
                             data: "eth0".into(),
@@ -2086,10 +2067,10 @@ testcases! {
                 bitwidth: IntegerWidth::Eight,
                 value: Box::new(DataItem::Array {
                     data: vec![
-                        DataItem::ByteString(ByteString {
-                            data: hex!("fe8000000000020202fffffffe030303").into(),
-                            bitwidth: IntegerWidth::Zero,
-                        }),
+                        DataItem::ByteString(ByteString::new(
+                            hex!("fe8000000000020202fffffffe030303"))
+                        .with_bitwidth(IntegerWidth::Zero)
+                        ),
                         DataItem::Integer {
                             value: 64,
                             bitwidth: IntegerWidth::Eight,
@@ -2118,10 +2099,10 @@ testcases! {
                 DataItem::Tag {
                     tag: Tag::TYPED_ARRAY_U16_BIG_ENDIAN,
                     bitwidth: IntegerWidth::Eight,
-                    value: Box::new(DataItem::ByteString(ByteString {
-                        data: hex!("000200040008000400100100").into(),
-                        bitwidth: IntegerWidth::Zero,
-                    })),
+                    value: Box::new(DataItem::ByteString(ByteString::new(
+                        hex!("000200040008000400100100"))
+                        .with_bitwidth(IntegerWidth::Zero)
+                    )),
                 },
                 indoc!("
                     d8 41      # typed array of u16, big endian, tag(65)
@@ -2139,10 +2120,10 @@ testcases! {
                 DataItem::Tag {
                     tag: Tag::TYPED_ARRAY_U8_CLAMPED,
                     bitwidth: IntegerWidth::Eight,
-                    value: Box::new(DataItem::ByteString(ByteString {
-                        data: hex!("020408041000").into(),
-                        bitwidth: IntegerWidth::Zero,
-                    })),
+                    value: Box::new(DataItem::ByteString(ByteString::new(
+                        hex!("020408041000"))
+                        .with_bitwidth(IntegerWidth::Zero)
+                    )),
                 },
                 indoc!("
                     d8 44    # typed array of u8, clamped, tag(68)
@@ -2160,10 +2141,10 @@ testcases! {
                 DataItem::Tag {
                     tag: Tag::TYPED_ARRAY_U64_LITTLE_ENDIAN,
                     bitwidth: IntegerWidth::Eight,
-                    value: Box::new(DataItem::ByteString(ByteString {
-                        data: hex!("00020004000800040010010000000001").into(),
-                        bitwidth: IntegerWidth::Zero,
-                    })),
+                    value: Box::new(DataItem::ByteString(ByteString::new(
+                        hex!("00020004000800040010010000000001"))
+                        .with_bitwidth(IntegerWidth::Zero)
+                    )),
                 },
                 indoc!("
                     d8 47                  # typed array of u64, little endian, tag(71)
@@ -2177,10 +2158,10 @@ testcases! {
                 DataItem::Tag {
                     tag: Tag::TYPED_ARRAY_I64_LITTLE_ENDIAN,
                     bitwidth: IntegerWidth::Eight,
-                    value: Box::new(DataItem::ByteString(ByteString {
-                        data: hex!("00020004000800040010010000000001").into(),
-                        bitwidth: IntegerWidth::Zero,
-                    })),
+                    value: Box::new(DataItem::ByteString(ByteString::new(
+                        hex!("00020004000800040010010000000001"))
+                        .with_bitwidth(IntegerWidth::Zero)
+                    )),
                 },
                 indoc!("
                     d8 4f                  # typed array of i64, little endian, twos-complement, tag(79)
@@ -2194,10 +2175,10 @@ testcases! {
                 DataItem::Tag {
                     tag: Tag::TYPED_ARRAY_F16_BIG_ENDIAN,
                     bitwidth: IntegerWidth::Eight,
-                    value: Box::new(DataItem::ByteString(ByteString {
-                        data: hex!("0002000400080004").into(),
-                        bitwidth: IntegerWidth::Zero,
-                    })),
+                    value: Box::new(DataItem::ByteString(ByteString::new(
+                        hex!("0002000400080004"))
+                        .with_bitwidth(IntegerWidth::Zero)
+                    )),
                 },
                 indoc!("
                     d8 50      # typed array of f16, big endian, tag(80)
@@ -2213,10 +2194,10 @@ testcases! {
                 DataItem::Tag {
                     tag: Tag::TYPED_ARRAY_F64_LITTLE_ENDIAN,
                     bitwidth: IntegerWidth::Eight,
-                    value: Box::new(DataItem::ByteString(ByteString {
-                        data: hex!("f2fff4fff8fff441").into(),
-                        bitwidth: IntegerWidth::Zero,
-                    })),
+                    value: Box::new(DataItem::ByteString(ByteString::new(
+                        hex!("f2fff4fff8fff441"))
+                        .with_bitwidth(IntegerWidth::Zero)
+                    )),
                 },
                 indoc!("
                     d8 56                  # typed array of f64, little endian, tag(86)
@@ -2229,10 +2210,10 @@ testcases! {
                 DataItem::Tag {
                     tag: Tag::TYPED_ARRAY_F128_LITTLE_ENDIAN,
                     bitwidth: IntegerWidth::Eight,
-                    value: Box::new(DataItem::ByteString(ByteString {
-                        data: hex!("3ff2fff4fff8fff43ff2fff4fff8fff4").into(),
-                        bitwidth: IntegerWidth::Zero,
-                    })),
+                    value: Box::new(DataItem::ByteString(ByteString::new(
+                        hex!("3ff2fff4fff8fff43ff2fff4fff8fff4"))
+                        .with_bitwidth(IntegerWidth::Zero)
+                    )),
                 },
                 indoc!("
                     d8 57                                  # typed array of f128, little endian, tag(87)
@@ -2245,10 +2226,10 @@ testcases! {
                 DataItem::Tag {
                     tag: Tag::TYPED_ARRAY_U16_BIG_ENDIAN,
                     bitwidth: IntegerWidth::Eight,
-                    value: Box::new(DataItem::ByteString(ByteString {
-                        data: hex!("000200").into(),
-                        bitwidth: IntegerWidth::Zero,
-                    })),
+                    value: Box::new(DataItem::ByteString(ByteString::new(
+                        hex!("000200"))
+                        .with_bitwidth(IntegerWidth::Zero)
+                    )),
                 },
                 indoc!(r#"
                     d8 41        # typed array of u16, big endian, tag(65)


### PR DESCRIPTION
This is a quick hack to show what, based on #142, preservation of diagnostic notation style of strings could look like.

This preserves just the encoding style, i.e. whether it's hex or base64 encoded (with some roughness around ASCII encoding not being preserved right). It does not preserve how the diagnostic notation strings is composed of multiple chunks (all of which could have their own encoding), or comments inside the (eg. hex) string. The latter would be tempting to add, the former I don't see an urgent need for.

It already shows how I think it would make sense to run those diagnostic-representation things: The encoder would have a preference, and if the item doesn't state how it is to be expressed, that encoder style triggers. But if the item has a style choice, that is followed. Methods could be provided to clear the encoding style, or to apply one (maybe in a callback from a walker).

This is a sketch for two reasons:
* If done properly, Encoding would be hoisted out of its current module and extended to have an explicit value for ASCII, and possibly extension to the rarer ones.
* It is based on the current #142, which is on its own a preview. Once that is complete, this PR will need more than a simple rebase.

This PR primarily serves to illustrate the road that can be taken after #142, and as a storage point for how the information can be passed around in the parser (took me a bit because I haven't used nom or similar before).