### PR TITLE
Allow trailing comma without trailing whitespace

### DIFF
--- a/src/parse/diag.rs
+++ b/src/parse/diag.rs
@@ -46,7 +46,7 @@ fn wrapws_strings<'a>(
 }
 
 fn opt_comma_tag<'a>(t: &'a str) -> impl FnMut(&'a str) -> IResult<&'a str, &'a str> {
-    alt((tag(t), map(tuple((tag(","), ws, tag(t))), |(_, (), f)| f)))
+    alt((tag(t), map(tuple((tag(","), many0_count(ws::<()>), tag(t))), |(_, _, f)| f)))
 }
 
 /// Recognizes one or more binary numerical characters: 0, 1

--- a/tests/array.rs
+++ b/tests/array.rs
@@ -39,6 +39,22 @@ testcases! {
             }
         }
 
+        hello_trailingcomma(diag2value) {
+            DataItem::Array {
+                data: vec![
+                    DataItem::TextString(TextString {
+                        data: "hello".into(),
+                        bitwidth: IntegerWidth::Unknown,
+                    }),
+                ],
+                bitwidth: Some(IntegerWidth::Unknown),
+            },
+            {
+                r#"["hello",]"#,
+                r#"["hello",]"#,
+            }
+        }
+
         hello_world(diag2value, value2diag) {
             DataItem::Array {
                 data: vec![

--- a/tests/map.rs
+++ b/tests/map.rs
@@ -39,6 +39,28 @@ testcases! {
             }
         }
 
+        hello_world_trailingcomma(diag2value) {
+            DataItem::Map {
+                data: vec![
+                    (
+                        DataItem::TextString(TextString {
+                            data: "hello".into(),
+                            bitwidth: IntegerWidth::Unknown,
+                        }),
+                        DataItem::TextString(TextString {
+                            data: "world".into(),
+                            bitwidth: IntegerWidth::Unknown,
+                        }),
+                    ),
+                ],
+                bitwidth: Some(IntegerWidth::Unknown),
+            },
+            {
+                r#"{"hello":"world",}"#,
+                r#"{"hello": "world",}"#,
+            }
+        }
+
         non_alpha(diag2value, value2diag) {
             DataItem::Map {
                 data: vec![


### PR DESCRIPTION
There were cases when a trailing comma (that is mostly allowed by this implementation, also by the upcoming spec, for but not tested) was not allowed:

```
$ echo '[1,2,3,]' | cargo run -- --from diag --to diag
Error: Failed all parsers
```

This patch fixes this by allowing the white space after the comma to be absent. I'm not sure that covers all the cases that were missing, but at least it covers a file I was using.